### PR TITLE
fix x86 pkg path

### DIFF
--- a/scripts/cross.sh
+++ b/scripts/cross.sh
@@ -36,7 +36,7 @@ case "$TARGETARCH" in
 "amd64")
   OUT_ARCH="x86_64"
   DPKG_ARCH="amd64"
-  PKG_PREFIX="x86_64-linux-gnu"
+  PKG_PREFIX="x86-64-linux-gnu"
   ;;
 "arm64")
   OUT_ARCH="aarch64"


### PR DESCRIPTION
https://packages.debian.org/search?suite=buster&section=all&arch=arm64&searchon=names&keywords=gcc-x86-64-linux

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>