### PR TITLE
github: install qemu for publish step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,9 @@ jobs:
           username: ${{ secrets.DOCKERIO_USERNAME }}
           password: ${{ secrets.DOCKERIO_PASSWORD }}
       -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      -
         name: Publish ${{ matrix.target }}
         run: |
           docker buildx bake --push --progress=plain \


### PR DESCRIPTION
Publish should normally use cache from the previous step but there seems to be a locking issue with the test matrix that can be fixed separately.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>