### PR TITLE
set pkgversion on configure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -75,7 +75,7 @@ FROM base-$TARGETARCH$TARGETVARIANT AS base
 
 FROM base AS build
 ARG TARGETPLATFORM
-ARG VERSION
+ARG QEMU_VERSION
 RUN --mount=target=.,from=src,src=/src/qemu,rw --mount=target=./install-scripts,src=scripts \
   TARGETPLATFORM=${TARGETPLATFORM} configure_qemu.sh && \
   make -j "$(getconf _NPROCESSORS_ONLN)" && \

--- a/scripts/configure_qemu.sh
+++ b/scripts/configure_qemu.sh
@@ -42,7 +42,7 @@ fi
 set -x
 ./configure \
   --prefix=/usr \
-  --with-pkgversion=$VERSION \
+  --with-pkgversion=$QEMU_VERSION \
   --enable-linux-user \
   --disable-system \
   --static \


### PR DESCRIPTION
Older versions of qemu (pre 5.2) seem to have trouble verifying
clean git checkout automatically. Currently the checkout is not clean
but I tested with fixing that and it still didn't work for old versions.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>