### PR TITLE
Fix release workflow (typo)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           REPO=$(docker buildx bake --print ${{ github.event.inputs.target }} | jq --raw-output '.. | .args?.QEMU_REPO | select(.)')
           if [ "${{ github.event.inputs.qemu_repo }}" != "" ]; then
-            QEMU_REPO=${{ github.event.inputs.qemu_repo }}
+            REPO=${{ github.event.inputs.qemu_repo }}
           fi
           REF=$(docker buildx bake --print ${{ github.event.inputs.target }} | jq --raw-output '.. | .args?.QEMU_VERSION | select(.)')
           if [ "${{ github.event.inputs.qemu_ref }}" != "" ]; then


### PR DESCRIPTION
Found a typo while trying to [build](https://github.com/tonistiigi/binfmt/actions/runs/995848902) from my fork https://github.com/crazy-max/qemu/tree/v6.0.0-shebang against buildkit target.