### PR TITLE
Add Helm chart to ease deployment on Kubernetes

### DIFF
--- a/charts/binfmt/Chart.yaml
+++ b/charts/binfmt/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: binfmt
+description: Cross-platform emulator collection
+type: application
+version: 0.1.0
+appVersion: "0.0.0"

--- a/charts/binfmt/README.md
+++ b/charts/binfmt/README.md
@@ -1,0 +1,27 @@
+# binfmt
+
+Cross-platform emulator collection
+
+# Usage
+
+Install and uninstall using Helm.
+
+For example, prepare all nodes for `arm64` emulation by running
+```sh
+helm install --wait binfmt-arm64 charts/binfmt --set formats=arm64
+helm uninstall
+```
+
+# Configuration
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| formats | string | `"all"` | a comma-separated list of [architecture formats](https://github.com/tonistiigi/binfmt) to enable or "all" |
+| | | | |
+| nameOverride | string | `""` | alternative to default chart name |
+| fullnameOverride | string | `""` | alternative to default fully qualified app name |
+| podAnnotations | object | `{}` | annotations for the pod |
+| resources | object | `{"limits": {"memory": "128Mi"}, "requests": {"cpu": "100m", "memory": "128Mi"}}` | resource definition for the pod |
+| nodeSelector | object | `{}` | selector that limits deployment to matching nodes |
+| tolerations | list | `[]` | tolerations (list of taint match definitions) for the pod |
+| affinity | object | `{}` | scheduling constraints for the pod |

--- a/charts/binfmt/templates/NOTES.txt
+++ b/charts/binfmt/templates/NOTES.txt
@@ -1,0 +1,8 @@
+This chart should be uninstalled as soon as successful deployment has been confirmed.
+
+The following commands do just that in `bash` (adapt as needed):
+
+until [[ "$(helm list --deployed -n {{ .Release.Namespace }} -qf {{ .Release.Name }})" = {{ .Release.Name }} ]]
+do sleep .5
+done
+helm uninstall --namespace {{ .Release.Namespace }} {{ .Release.Name }}

--- a/charts/binfmt/templates/_helpers.tpl
+++ b/charts/binfmt/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "binfmt.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "binfmt.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "binfmt.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "binfmt.labels" -}}
+helm.sh/chart: {{ include "binfmt.chart" . }}
+{{ include "binfmt.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "binfmt.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "binfmt.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/binfmt/templates/daemonset.yaml
+++ b/charts/binfmt/templates/daemonset.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "binfmt.fullname" . }}
+  labels:
+    {{- include "binfmt.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "binfmt.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "binfmt.selectorLabels" . | nindent 8 }}
+    spec:
+      initContainers:
+        - name: {{ .Chart.Name }}-installer
+          securityContext:
+            privileged: true
+          imagePullPolicy: Always
+          image: tonistiigi/binfmt
+          args:
+            - --install
+            - {{ .Values.formats }}
+      containers:
+        - name: {{ .Chart.Name }}-idle
+          image: busybox
+          command:
+            - tail
+            - -F
+            - whatever
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/binfmt/values.yaml
+++ b/charts/binfmt/values.yaml
@@ -1,0 +1,21 @@
+# a comma-separated list of architecture formats to enable or "all"
+# see https://github.com/tonistiigi/binfmt for details
+formats: "all"
+
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+resources:
+  limits:
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Standard fare Helm chart with `formats` as the only `binfmt`-specific configuration option
and a subset of standard options that allow Kubernetes administrators to select a subset
of nodes for installation.