### PR TITLE
add patches for supporting sched syscalls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
         uses: docker/setup-buildx-action@v1
         with:
           config: .github/buildkit.toml
+          buildkitd-flags: --allow-insecure-entitlement=security.insecure
       -
         name: Test buildkit
         if: matrix.target == 'buildkit'
@@ -110,6 +111,11 @@ jobs:
           docker run --rm --platform=linux/s390x s390x/ubuntu apt update
           docker run --rm --platform=linux/ppc64le ppc64le/ubuntu apt update
           docker run --rm --platform=linux/arm64 arm64v8/ubuntu apt update
+      - name: Test Syscalls
+        if: matrix.target == 'mainline'
+        run: |
+          set -x
+          docker buildx build --platform=linux/amd64,linux/arm64,linux/386,linux/arm,linux/ppc64le,linux/s390x --target=run --allow security.insecure --build-arg CONFIG_RT_GROUP_SCHED=false ./test
       -
         name: Login to DockerHub
         if: startsWith(github.ref, 'refs/heads/')

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ ARG QEMU_REPO
 RUN git clone $QEMU_REPO && cd qemu && git checkout $QEMU_VERSION
 COPY patches patches
 ARG QEMU_PATCHES=cpu-max
-ARG QEMU_PATCHES_ALL=${QEMU_PATCHES},alpine-patches,zero-init-msghdr
+ARG QEMU_PATCHES_ALL=${QEMU_PATCHES},alpine-patches,zero-init-msghdr,sched
 RUN <<eof
   set -ex
   if [ "${QEMU_PATCHES_ALL#*alpine-patches}" != "${QEMU_PATCHES_ALL}" ]; then

--- a/patches/sched/0001-linux-user-add-sched_getattr-support.patch
+++ b/patches/sched/0001-linux-user-add-sched_getattr-support.patch
@@ -1,0 +1,113 @@
+From a5684131713a125db821dad045d942b662b461b8 Mon Sep 17 00:00:00 2001
+From: Tonis Tiigi <tonistiigi@gmail.com>
+Date: Tue, 30 Nov 2021 12:43:32 -0800
+Subject: [PATCH 1/2] linux-user: add sched_getattr support
+
+Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
+---
+ linux-user/syscall.c      | 56 +++++++++++++++++++++++++++++++++++++++
+ linux-user/syscall_defs.h | 16 +++++++++++
+ 2 files changed, 72 insertions(+)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index f1cfcc8104..10965bbe4d 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -339,6 +339,10 @@ _syscall3(int, sys_sched_getaffinity, pid_t, pid, unsigned int, len,
+ #define __NR_sys_sched_setaffinity __NR_sched_setaffinity
+ _syscall3(int, sys_sched_setaffinity, pid_t, pid, unsigned int, len,
+           unsigned long *, user_mask_ptr);
++#define __NR_sys_sched_getattr __NR_sched_getattr
++_syscall4(int, sys_sched_getattr, pid_t, pid, struct sched_attr *, attr, unsigned int, size, unsigned int, flags);
++#define __NR_sys_sched_setattr __NR_sched_setattr
++_syscall3(int, sys_sched_setattr, pid_t, pid, struct sched_attr *, attr, unsigned int, flags);
+ #define __NR_sys_getcpu __NR_getcpu
+ _syscall3(int, sys_getcpu, unsigned *, cpu, unsigned *, node, void *, tcache);
+ _syscall4(int, reboot, int, magic1, int, magic2, unsigned int, cmd,
+@@ -10593,6 +10597,58 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+         }
+     case TARGET_NR_sched_getscheduler:
+         return get_errno(sched_getscheduler(arg1));
++    case TARGET_NR_sched_getattr:
++        {
++            struct target_sched_attr *target_scha;
++            struct target_sched_attr scha;
++            if (arg2 == 0) {
++                return -TARGET_EINVAL;
++            }
++            ret = get_errno(sys_sched_getattr(arg1, &scha, arg3, arg4));
++            if (!is_error(ret)) {
++                if (!lock_user_struct(VERIFY_WRITE, target_scha, arg2, 0))
++                    return -TARGET_EFAULT;
++                target_scha->size = tswap32(scha.size);
++                target_scha->sched_policy = tswap32(scha.sched_policy);
++                target_scha->sched_flags = tswap64(scha.sched_policy);
++                target_scha->sched_nice = tswap32(scha.sched_nice);
++                target_scha->sched_priority = tswap32(scha.sched_priority);
++                target_scha->sched_runtime = tswap64(scha.sched_runtime);
++                target_scha->sched_deadline = tswap64(scha.sched_deadline);
++                target_scha->sched_period = tswap64(scha.sched_period);
++                if (scha.size >= 0x38) {
++                    target_scha->sched_util_min = tswap32(scha.sched_util_min);
++                    target_scha->sched_util_max = tswap32(scha.sched_util_max);
++                }
++                unlock_user_struct(target_scha, arg2, 1);
++            }
++            return ret;
++        }
++    case TARGET_NR_sched_setattr:
++        {
++            struct target_sched_attr *target_scha;
++            struct target_sched_attr scha;
++            if (arg2 == 0) {
++                return -TARGET_EINVAL;
++            }
++            if (!lock_user_struct(VERIFY_READ, target_scha, arg2, 1))
++                return -TARGET_EFAULT;
++            scha.size = tswap32(target_scha->size);
++            scha.sched_policy = tswap32(target_scha->sched_policy);
++            scha.sched_flags = tswap64(target_scha->sched_flags);
++            scha.sched_nice = tswap32(target_scha->sched_nice);
++            scha.sched_priority = tswap32(target_scha->sched_priority);
++            scha.sched_runtime = tswap64(target_scha->sched_runtime);
++            scha.sched_deadline = tswap64(target_scha->sched_deadline);
++            scha.sched_period = tswap64(target_scha->sched_period);
++            if (scha.size >= 0x38) {
++                scha.sched_util_min = tswap32(target_scha->sched_util_min);
++                scha.sched_util_max = tswap32(target_scha->sched_util_max);
++            }
++            
++            unlock_user_struct(target_scha, arg2, 0);
++            return get_errno(sys_sched_setattr(arg1, &scha, arg3));
++        }
+     case TARGET_NR_sched_yield:
+         return get_errno(sched_yield());
+     case TARGET_NR_sched_get_priority_max:
+diff --git a/linux-user/syscall_defs.h b/linux-user/syscall_defs.h
+index 0b13975937..b1a76bb81a 100644
+--- a/linux-user/syscall_defs.h
++++ b/linux-user/syscall_defs.h
+@@ -2914,4 +2914,20 @@ struct target_statx {
+    /* 0x100 */
+ };
+ 
++// we can not include /usr/include/linux/sched/types.h becuse
++// it conflicts with libc headers but libc does not define sched_attr
++struct target_sched_attr {
++    uint32_t size;
++    uint32_t sched_policy;
++    uint64_t sched_flags;
++    int32_t sched_nice;
++    uint32_t sched_priority;
++    uint64_t sched_runtime;
++    uint64_t sched_deadline;
++    uint64_t sched_period;
++    // 0x30
++    uint32_t sched_util_min;
++    uint32_t sched_util_max;
++};
++
+ #endif
+-- 
+2.30.1 (Apple Git-130)
+

--- a/patches/sched/0002-linux-user-call-set-getscheduler-set-getparam-direct.patch
+++ b/patches/sched/0002-linux-user-call-set-getscheduler-set-getparam-direct.patch
@@ -1,0 +1,68 @@
+From e50adaa57c74e24db012c6384f1f5c664e0c0d0b Mon Sep 17 00:00:00 2001
+From: Tonis Tiigi <tonistiigi@gmail.com>
+Date: Fri, 3 Dec 2021 23:12:59 -0800
+Subject: [PATCH 2/2] linux-user: call set/getscheduler set/getparam directly
+
+There seems to be difference in syscall and libc definition of these
+methods and therefore musl does not implement them (1e21e78bf7). Call
+syscall directly to ensure the behavior of the libc of user application,
+not the libc that was used to build QEMU.
+
+Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
+---
+ linux-user/syscall.c | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/linux-user/syscall.c b/linux-user/syscall.c
+index 10965bbe4d..7010263874 100644
+--- a/linux-user/syscall.c
++++ b/linux-user/syscall.c
+@@ -343,6 +343,14 @@ _syscall3(int, sys_sched_setaffinity, pid_t, pid, unsigned int, len,
+ _syscall4(int, sys_sched_getattr, pid_t, pid, struct sched_attr *, attr, unsigned int, size, unsigned int, flags);
+ #define __NR_sys_sched_setattr __NR_sched_setattr
+ _syscall3(int, sys_sched_setattr, pid_t, pid, struct sched_attr *, attr, unsigned int, flags);
++#define __NR_sys_sched_getscheduler __NR_sched_getscheduler
++_syscall1(int, sys_sched_getscheduler, pid_t, pid);
++#define __NR_sys_sched_setscheduler __NR_sched_setscheduler
++_syscall3(int, sys_sched_setscheduler, pid_t, pid, int, policy, const struct sched_param *, param);
++#define __NR_sys_sched_getparam __NR_sched_getparam
++_syscall2(int, sys_sched_getparam, pid_t, pid, struct sched_param *, param);
++#define __NR_sys_sched_setparam __NR_sched_setparam
++_syscall2(int, sys_sched_setparam, pid_t, pid, const struct sched_param *, param);
+ #define __NR_sys_getcpu __NR_getcpu
+ _syscall3(int, sys_getcpu, unsigned *, cpu, unsigned *, node, void *, tcache);
+ _syscall4(int, reboot, int, magic1, int, magic2, unsigned int, cmd,
+@@ -10563,7 +10571,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+                 return -TARGET_EFAULT;
+             schp.sched_priority = tswap32(target_schp->sched_priority);
+             unlock_user_struct(target_schp, arg2, 0);
+-            return get_errno(sched_setparam(arg1, &schp));
++            return get_errno(sys_sched_setparam(arg1, &schp));
+         }
+     case TARGET_NR_sched_getparam:
+         {
+@@ -10573,7 +10581,7 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+             if (arg2 == 0) {
+                 return -TARGET_EINVAL;
+             }
+-            ret = get_errno(sched_getparam(arg1, &schp));
++            ret = get_errno(sys_sched_getparam(arg1, &schp));
+             if (!is_error(ret)) {
+                 if (!lock_user_struct(VERIFY_WRITE, target_schp, arg2, 0))
+                     return -TARGET_EFAULT;
+@@ -10593,10 +10601,10 @@ static abi_long do_syscall1(void *cpu_env, int num, abi_long arg1,
+                 return -TARGET_EFAULT;
+             schp.sched_priority = tswap32(target_schp->sched_priority);
+             unlock_user_struct(target_schp, arg3, 0);
+-            return get_errno(sched_setscheduler(arg1, arg2, &schp));
++            return get_errno(sys_sched_setscheduler(arg1, arg2, &schp));
+         }
+     case TARGET_NR_sched_getscheduler:
+-        return get_errno(sched_getscheduler(arg1));
++        return get_errno(sys_sched_getscheduler(arg1));
+     case TARGET_NR_sched_getattr:
+         {
+             struct target_sched_attr *target_scha;
+-- 
+2.30.1 (Apple Git-130)
+

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,30 @@
+#syntax=docker/dockerfile:1.3-labs
+
+FROM --platform=$BUILDPLATFORM tonistiigi/xx:1.1.0 AS xx
+
+FROM scratch AS src
+COPY *.go go.* /
+
+FROM --platform=$BUILDPLATFORM golang:1.17-alpine AS build
+COPY --from=xx / /
+RUN apk add clang lld file
+ARG TARGETPLATFORM
+RUN xx-apk add musl-dev linux-headers gcc
+WORKDIR /src
+RUN XX_CC_PREFER_STATIC_LINKER=1 xx-clang --setup-target-triple
+RUN --mount=from=src \
+    --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg \
+    CGO_ENABLED=1 xx-go test -c -o /out/test -ldflags "-linkmode external -extldflags -static" . && \
+    xx-verify --static /out/test
+
+FROM scratch AS binary
+COPY --from=build /out/test .
+
+FROM alpine AS run
+RUN apk add libcap
+COPY --from=binary / /usr/bin
+ARG CONFIG_RT_GROUP_SCHED
+RUN --security=insecure /usr/bin/test -test.v
+
+FROM binary

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,0 +1,14 @@
+module github.com/tonistiigi/binfmt/test
+
+go 1.17
+
+require (
+	github.com/stretchr/testify v1.7.0
+	golang.org/x/sys v0.0.0-20211124211545-fe61309f8881
+)
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+golang.org/x/sys v0.0.0-20211124211545-fe61309f8881 h1:TyHqChC80pFkXWraUUf6RuB5IqFdQieMLwwCJokV2pc=
+golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/sched.go
+++ b/test/sched.go
@@ -1,0 +1,122 @@
+package tests
+
+import (
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// #include <linux/sched.h>
+// #include <linux/sched/types.h>
+// typedef struct sched_param sched_param;
+import "C"
+
+type Policy uint32
+
+const (
+	SCHED_NORMAL   Policy = C.SCHED_NORMAL
+	SCHED_FIFO     Policy = C.SCHED_FIFO
+	SCHED_RR       Policy = C.SCHED_RR
+	SCHED_BATCH    Policy = C.SCHED_BATCH
+	SCHED_IDLE     Policy = C.SCHED_IDLE
+	SCHED_DEADLINE Policy = C.SCHED_DEADLINE
+)
+
+type SchedFlag int
+
+const (
+	SCHED_FLAG_RESET_ON_FORK SchedFlag = C.SCHED_FLAG_RESET_ON_FORK
+	SCHED_FLAG_RECLAIM       SchedFlag = C.SCHED_FLAG_RECLAIM
+	SCHED_FLAG_DL_OVERRUN    SchedFlag = C.SCHED_FLAG_DL_OVERRUN
+)
+
+type SchedParam C.sched_param
+
+func SchedGetScheduler(pid int) (Policy, error) {
+	r0, _, e1 := unix.Syscall(unix.SYS_SCHED_GETSCHEDULER, uintptr(pid), 0, 0)
+	if e1 != 0 {
+		return 0, syscall.Errno(e1)
+	}
+	return Policy(r0), nil
+}
+
+func SchedSetScheduler(pid int, p Policy, param SchedParam) error {
+	_, _, e1 := unix.Syscall(unix.SYS_SCHED_SETSCHEDULER, uintptr(pid), uintptr(p), uintptr(unsafe.Pointer(&param)))
+	if e1 != 0 {
+		return syscall.Errno(e1)
+	}
+	return nil
+}
+
+func SchedGetPriorityMin(p Policy) (int, error) {
+	r0, _, e1 := unix.Syscall(unix.SYS_SCHED_GET_PRIORITY_MIN, uintptr(p), 0, 0)
+	if e1 != 0 {
+		return 0, syscall.Errno(e1)
+	}
+	return int(r0), nil
+}
+
+func SchedGetPriorityMax(p Policy) (int, error) {
+	r0, _, e1 := unix.Syscall(unix.SYS_SCHED_GET_PRIORITY_MAX, uintptr(p), 0, 0)
+	if e1 != 0 {
+		return 0, syscall.Errno(e1)
+	}
+	return int(r0), nil
+}
+
+func SchedYield() error {
+	_, _, e1 := unix.Syscall(unix.SYS_SCHED_YIELD, 0, 0, 0)
+	if e1 != 0 {
+		return syscall.Errno(e1)
+	}
+	return nil
+}
+
+func SchedGetParam(pid int) (SchedParam, error) {
+	var param SchedParam
+	_, _, e1 := unix.Syscall(unix.SYS_SCHED_GETPARAM, uintptr(pid), uintptr(unsafe.Pointer(&param)), 0)
+	if e1 != 0 {
+		return param, syscall.Errno(e1)
+	}
+	return param, nil
+}
+
+func SchedSetParam(pid int, param SchedParam) error {
+	_, _, e1 := unix.Syscall(unix.SYS_SCHED_SETPARAM, uintptr(pid), uintptr(unsafe.Pointer(&param)), 0)
+	if e1 != 0 {
+		return syscall.Errno(e1)
+	}
+	return nil
+}
+
+type SchedAttr struct {
+	Size          uint32
+	SchedPolicy   Policy
+	SchedFlags    uint64
+	SchedNice     uint32
+	SchedPriority uint32
+	SchedRuntime  uint64
+	SchedDeadline uint64
+	SchedPeriod   uint64
+	SchedUtilMin  uint32
+	SchedUtilMax  uint32
+}
+
+func SchedGetAttr(pid int) (SchedAttr, error) {
+	var attr SchedAttr
+	_, _, e1 := unix.Syscall6(unix.SYS_SCHED_GETATTR, uintptr(pid), uintptr(unsafe.Pointer(&attr)), unsafe.Sizeof(SchedAttr{}), 0, 0, 0)
+	if e1 != 0 {
+		return attr, syscall.Errno(e1)
+	}
+	return attr, nil
+}
+
+func SchedSetAttr(pid int, attr SchedAttr, flags SchedFlag) error {
+	attr.Size = uint32(unsafe.Sizeof(attr))
+	_, _, e1 := unix.Syscall(unix.SYS_SCHED_SETATTR, uintptr(pid), uintptr(unsafe.Pointer(&attr)), uintptr(flags))
+	if e1 != 0 {
+		return syscall.Errno(e1)
+	}
+	return nil
+}

--- a/test/sched_test.go
+++ b/test/sched_test.go
@@ -1,0 +1,152 @@
+package tests
+
+import (
+	"errors"
+	"os"
+	"runtime"
+	"strconv"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var CONFIG_RT_GROUP_SCHED bool = true
+
+func init() {
+	runtime.LockOSThread()
+
+	if v := os.Getenv("CONFIG_RT_GROUP_SCHED"); v != "" {
+		if vv, err := strconv.ParseBool(v); err == nil {
+			CONFIG_RT_GROUP_SCHED = vv
+		}
+	}
+}
+
+func TestGetSetScheduler(t *testing.T) {
+	_, err := SchedGetScheduler(1 << 30)
+	require.Error(t, err)
+
+	pid := os.Getpid()
+	s, err := SchedGetScheduler(pid)
+	require.NoError(t, err)
+	require.Equal(t, SCHED_NORMAL, s)
+
+	// priority
+	err = SchedSetScheduler(pid, SCHED_RR, SchedParam{
+		sched_priority: 100,
+	})
+	require.True(t, errors.Is(err, syscall.EINVAL))
+
+	err = SchedSetScheduler(pid, SCHED_RR, SchedParam{
+		sched_priority: 90,
+	})
+	require.True(t, !errors.Is(err, syscall.EINVAL))
+
+	if CONFIG_RT_GROUP_SCHED {
+		t.Logf("skipping scheduler set checks")
+	} else {
+		require.NoError(t, err)
+
+		s, err := SchedGetScheduler(pid)
+		require.NoError(t, err)
+		require.Equal(t, SCHED_RR, s)
+
+		p, err := SchedGetParam(pid)
+		require.NoError(t, err)
+		require.Equal(t, 90, int(p.sched_priority))
+	}
+
+	err = SchedSetScheduler(pid, SCHED_IDLE, SchedParam{})
+	require.NoError(t, err)
+
+	s, err = SchedGetScheduler(pid)
+	require.NoError(t, err)
+	require.Equal(t, SCHED_IDLE, s)
+
+	err = SchedSetScheduler(pid, SCHED_NORMAL, SchedParam{})
+	require.NoError(t, err)
+}
+
+func TestSchedMinMax(t *testing.T) {
+	p, err := SchedGetPriorityMin(SCHED_RR)
+	require.NoError(t, err)
+	require.Equal(t, 1, p)
+
+	p, err = SchedGetPriorityMax(SCHED_RR)
+	require.NoError(t, err)
+	require.Equal(t, 99, p)
+
+	p, err = SchedGetPriorityMax(SCHED_BATCH)
+	require.NoError(t, err)
+	require.Equal(t, 0, p)
+}
+
+func TestSchedYield(t *testing.T) {
+	err := SchedYield()
+	require.NoError(t, err)
+}
+
+func TestSchedGetSetParam(t *testing.T) {
+	pid := os.Getpid()
+
+	p, err := SchedGetParam(pid)
+	require.NoError(t, err)
+
+	require.Equal(t, 0, int(p.sched_priority))
+
+	err = SchedSetParam(pid, SchedParam{})
+	require.NoError(t, err)
+
+	if CONFIG_RT_GROUP_SCHED {
+		t.Logf("skipping setting sched_priority")
+	} else {
+		err = SchedSetScheduler(pid, SCHED_RR, SchedParam{sched_priority: 50})
+		require.NoError(t, err)
+
+		p, err := SchedGetParam(pid)
+		require.NoError(t, err)
+
+		require.Equal(t, 50, int(p.sched_priority))
+	}
+}
+
+func TestSchedAttr(t *testing.T) {
+	pid := os.Getpid()
+
+	if !CONFIG_RT_GROUP_SCHED {
+		err := SchedSetScheduler(pid, SCHED_RR, SchedParam{sched_priority: 50})
+		require.NoError(t, err)
+	}
+
+	attr, err := SchedGetAttr(pid)
+	require.NoError(t, err)
+
+	require.True(t, attr.Size >= 0x30)
+
+	if CONFIG_RT_GROUP_SCHED {
+		require.Equal(t, SCHED_NORMAL, attr.SchedPolicy)
+
+		attr := SchedAttr{SchedPolicy: SCHED_IDLE}
+		err := SchedSetAttr(pid, attr, 0)
+		require.NoError(t, err)
+
+		attr, err = SchedGetAttr(pid)
+		require.NoError(t, err)
+		require.Equal(t, SCHED_IDLE, attr.SchedPolicy)
+
+		t.Logf("skipping setting attr priority")
+	} else {
+		require.Equal(t, SCHED_RR, attr.SchedPolicy)
+		require.Equal(t, 50, int(attr.SchedPriority))
+
+		attr := SchedAttr{SchedPolicy: SCHED_RR, SchedPriority: 60}
+		err := SchedSetAttr(pid, attr, 0)
+		require.NoError(t, err)
+
+		attr, err = SchedGetAttr(pid)
+		require.NoError(t, err)
+		require.Equal(t, SCHED_RR, attr.SchedPolicy)
+		require.Equal(t, 60, int(attr.SchedPriority))
+	}
+}


### PR DESCRIPTION
fix #69

~Just wip atm as there are other cases to consider.~

Attr syscalls are missing for glibc builds as well. Afaics it doesn't fail because `chrt` has a fallback to `sched_getscheduler(2)` and that is `ENOSYS` in musl https://github.com/bminor/musl/blob/master/src/sched/sched_getscheduler.c . I'm not sure if `ENOSYS` there is expected or not. Theoretically, qemu doesn't need to call libc for these as well and can just call syscall directly.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>