### PR TITLE
enable preserve-argv0 by default on mainline

### DIFF
--- a/cmd/binfmt/main.go
+++ b/cmd/binfmt/main.go
@@ -67,7 +67,7 @@ func install(arch string) error {
 		binaryPath = v
 	}
 	flags := "CF"
-	if v := os.Getenv("QEMU_PRESERVE_PARENT"); v != "" {
+	if v := os.Getenv("QEMU_PRESERVE_ARGV0"); v != "" {
 		flags += "P"
 	}
 	binaryBasename := cfg.binary

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -40,6 +40,7 @@ target "mainline" {
   args = {
     QEMU_REPO = QEMU_REPO
     QEMU_VERSION = QEMU_VERSION
+    QEMU_PRESERVE_ARGV0 = "1"
   }
   cache-to = ["type=inline"]
   cache-from = ["${REPO}:master"]
@@ -54,6 +55,7 @@ target "buildkit" {
   args = {
     BINARY_PREFIX = "buildkit-"
     QEMU_PATCHES = "cpu-max,buildkit-direct-execve-v6.1"
+    QEMU_PRESERVE_ARGV0 = ""
   }
   cache-from = ["${REPO}:buildkit-master"]
   target = "binaries"

--- a/patches/preserve-argv0/0001-linux-user-default-to-preserve-argv0.patch
+++ b/patches/preserve-argv0/0001-linux-user-default-to-preserve-argv0.patch
@@ -1,0 +1,29 @@
+From eb4410de7f5297c643081e79a89f226210e3f4dd Mon Sep 17 00:00:00 2001
+From: Tonis Tiigi <tonistiigi@gmail.com>
+Date: Thu, 20 Jan 2022 20:21:07 -0800
+Subject: [PATCH] linux-user: default to preserve-argv0
+
+Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>
+---
+ linux-user/main.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/linux-user/main.c b/linux-user/main.c
+index 37ed50d98e..87e76845dc 100644
+--- a/linux-user/main.c
++++ b/linux-user/main.c
+@@ -706,6 +706,11 @@ int main(int argc, char **argv, char **envp)
+      * get binfmt_misc flags
+      */
+     preserve_argv0 = !!(qemu_getauxval(AT_FLAGS) & AT_FLAGS_PRESERVE_ARGV0);
++    
++    // default to preserve_argv0 on older kernels
++    if (qemu_getauxval(AT_FLAGS) == 0) {
++      preserve_argv0 = 1;
++    }
+ 
+     /*
+      * Manage binfmt-misc preserve-arg[0] flag
+-- 
+2.32.0 (Apple Git-132)
+

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -25,6 +25,6 @@ FROM alpine AS run
 RUN apk add libcap
 COPY --from=binary / /usr/bin
 ARG CONFIG_RT_GROUP_SCHED
-RUN --security=insecure /usr/bin/test -test.v
+RUN --security=insecure REEXEC_NAME=/usr/bin/test /usr/bin/test -test.v
 
 FROM binary

--- a/test/argv0_test.go
+++ b/test/argv0_test.go
@@ -1,0 +1,33 @@
+package tests
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func init() {
+	if v := os.Getenv("BINFMT_ARGV0_TEST"); v != "" {
+		fmt.Println(strings.Join(os.Args, ","))
+		os.Exit(0)
+	}
+}
+
+func TestArgv0(t *testing.T) {
+	self := "/proc/self/exe"
+	if v, ok := os.LookupEnv("REEXEC_NAME"); ok {
+		self = v
+	}
+	cmd := &exec.Cmd{
+		Path: self,
+		Env:  []string{"BINFMT_ARGV0_TEST=1"},
+		Args: []string{"first", "second", "third"},
+	}
+	out, err := cmd.CombinedOutput()
+	require.Equal(t, "first,second,third\n", string(out))
+	require.NoError(t, err)
+}


### PR DESCRIPTION
fixes docker/for-mac#6127

P flag is needed in order for qemu to not lose
argv0 value. Problem is that qemu can only detect that
flag was set on 5.12+ kernels and if it doesn’t detect
it then all argument values are wrong.

This introduces a patch that is enabled on mainline
target that assumes P flag was set if the kernel does
not provide any flags.

Signed-off-by: Tonis Tiigi <tonistiigi@gmail.com>