### PR TITLE
exclude arches with non-existing binary from allArch

### DIFF
--- a/cmd/binfmt/config.go
+++ b/cmd/binfmt/config.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"log"
+	"os"
 
 	"github.com/containerd/containerd/platforms"
 	"github.com/moby/buildkit/util/archutil"
@@ -80,7 +81,11 @@ func allArch() []string {
 	out := make([]string, 0, len(configs))
 	for name := range configs {
 		if _, ok := m[name]; !ok {
-			out = append(out, name)
+			if _, fullPath, err := getBinaryNames(configs[name]); err == nil {
+				if _, err := os.Stat(fullPath); err == nil {
+					out = append(out, name)
+				}
+			}
 		}
 	}
 	return out


### PR DESCRIPTION
If the docker is built with some QEMU_TARGETS excluded, e.g.
```
docker build --build-arg QEMU_TARGETS='x86_64-linux-user s390x-linux-user' -t binfmt .
```
then you get a lot of ugly errors when using `--install all`:
```
mikan% docker run --privileged --rm binfmt --install all
installing: s390x OK
installing: ppc64le cannot register "/usr/bin/qemu-ppc64le" to /proc/sys/fs/binfmt_misc/register: write /proc/sys/fs/binfmt_misc/register: no such file or directory
installing: riscv64 cannot register "/usr/bin/qemu-riscv64" to /proc/sys/fs/binfmt_misc/register: write /proc/sys/fs/binfmt_misc/register: no such file or directory
installing: mips64 cannot register "/usr/bin/qemu-mips64" to /proc/sys/fs/binfmt_misc/register: write /proc/sys/fs/binfmt_misc/register: no such file or directory
installing: amd64 OK
installing: arm cannot register "/usr/bin/qemu-arm" to /proc/sys/fs/binfmt_misc/register: write /proc/sys/fs/binfmt_misc/register: no such file or directory
installing: 386 cannot register "/usr/bin/qemu-i386" to /proc/sys/fs/binfmt_misc/register: write /proc/sys/fs/binfmt_misc/register: no such file or directory
installing: mips64le cannot register "/usr/bin/qemu-mips64el" to /proc/sys/fs/binfmt_misc/register: write /proc/sys/fs/binfmt_misc/register: no such file or directory
{
  "supported": [
    "linux/arm64",
    "linux/amd64",
    "linux/amd64/v2",
    "linux/s390x"
  ],
  "emulators": [
    "qemu-s390x",
    "qemu-x86_64"
  ]
}
```

This PR changes `all` from meaning "all arches that are not currently registered and for which a qemu binary _might_ be included" into meaning "all arches that are not currently registered and for which a qemu binary is _actually_ included".  😸  