### PR TITLE
ci: scheduled build to avoid gha cache being evicted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: ci
 
 on:
+  schedule:
+    - cron: '0 8 */6 * *' # every 6 days
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION
schedule build workflow to avoid cache being evicted:

> GitHub will remove any cache entries that have not been accessed in over 7 days.
https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>