### PR TITLE
ci: fix binfmt gh release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,15 +119,16 @@ jobs:
           set: |
             *.cache-from=${{ env.REPO_SLUG }}:${{ steps.prep.outputs.tag_prefix }}${{ github.event.inputs.qemu_version }},${{ env.REPO_SLUG }}:${{ steps.prep.outputs.tag_prefix }}master
             *.cache-from=type=gha,scope=${{ env.CACHE_GHA_SCOPE_CROSS }}-${{ github.event.inputs.target }}
+            *.output=type=local,dest=./bin,platform-split=false
         env:
           REPO: ${{ env.REPO_SLUG }}
           QEMU_REPO: ${{ steps.prep.outputs.repo }}
           QEMU_VERSION: ${{ steps.prep.outputs.ref }}
       -
-        name: Move artifacts
+        name: List artifacts
         if: github.event.inputs.target == 'mainline'
         run: |
-          mv ./bin/**/* ./bin/
+          tree -nh ./bin
       -
         name: Create Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844  # v0.1.15


### PR DESCRIPTION
related to https://github.com/tonistiigi/binfmt/actions/runs/7842729670/job/21403764984#step:10:32

![image](https://github.com/tonistiigi/binfmt/assets/1951866/0f35a753-246e-4d1c-99d9-eb839c5a0b55)

since https://github.com/tonistiigi/binfmt/pull/158, provenance is created by default with bake action v4. Fix the issue by disabling platform split behavior for the output.

Will look like this:

![image](https://github.com/tonistiigi/binfmt/assets/1951866/6a25eeb7-c9b5-4420-9bea-667b32ccf324)
 As provenance is for both binfmt and qemu bins I think the name is fine or maybe you would want a provenance attached to each binary so deidcated stage in dockerfile?