### PR TITLE
Add patch for docker/for-mac/issues/7172

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -80,7 +80,7 @@ target "buildkit-test" {
 target "desktop" {
   inherits = ["mainline"]
   args = {
-    QEMU_PATCHES = "${QEMU_PATCHES},subreaper-prctl"
+    QEMU_PATCHES = "${QEMU_PATCHES},subreaper-prctl,pretcode"
   }
   cache-from = ["${REPO}:desktop-master"]
 }

--- a/patches/pretcode/0001-incorrect-alignment-pretcode.patch
+++ b/patches/pretcode/0001-incorrect-alignment-pretcode.patch
@@ -1,0 +1,51 @@
+From: fanwj
+Subject: [PATCH] linux-user: fix incorrect alignment of pretcode
+Date: Fri, 12 May 2023 23:38:34 +0800 (GMT+08:00)
+sigframe::pretcode & rt_sigframe::pretcode must align of 16n-sizeof(void*) 
+instead of 16n, Because rsp align of 16n before instruction "call" in caller, 
+After "call", push address of "call" in caller. sp of begin in callee is 
+16n-sizeof(void*)
+
+Resolves: https://gitlab.com/qemu-project/qemu/-/issues/1648
+Signed-off-by: Fan WenJie <fanwj@mail.ustc.edu.cn>
+
+---
+ linux-user/i386/signal.c | 9 ++++++---
+ 1 file changed, 6 insertions(+), 3 deletions(-)
+
+diff --git a/linux-user/i386/signal.c b/linux-user/i386/signal.c
+index 60fa07d6f9c..1f019689ae7 100644
+--- a/linux-user/i386/signal.c
++++ b/linux-user/i386/signal.c
+@@ -197,7 +197,8 @@ struct sigframe {
+      * to it ensures that the base of the frame has an appropriate alignment
+      * too.
+      */
+-    struct target_fpstate fpstate QEMU_ALIGNED(8);
++    abi_ulong unused QEMU_ALIGNED(8);
++    struct target_fpstate fpstate;
+ };
+ #define TARGET_SIGFRAME_FXSAVE_OFFSET (                                    \
+     offsetof(struct sigframe, fpstate) + TARGET_FPSTATE_FXSAVE_OFFSET)
+@@ -210,7 +211,8 @@ struct rt_sigframe {
+     struct target_siginfo info;
+     struct target_ucontext uc;
+     char retcode[8];
+-    struct target_fpstate fpstate QEMU_ALIGNED(8);
++    abi_ulong unused QEMU_ALIGNED(8);
++    struct target_fpstate fpstate;
+ };
+ #define TARGET_RT_SIGFRAME_FXSAVE_OFFSET (                                 \
+     offsetof(struct rt_sigframe, fpstate) + TARGET_FPSTATE_FXSAVE_OFFSET)
+@@ -220,7 +222,8 @@ struct rt_sigframe {
+     abi_ulong pretcode;
+     struct target_ucontext uc;
+     struct target_siginfo info;
+-    struct target_fpstate fpstate QEMU_ALIGNED(16);
++    abi_ulong unused QEMU_ALIGNED(16);
++    struct target_fpstate fpstate;
+ };
+ #define TARGET_RT_SIGFRAME_FXSAVE_OFFSET (                                 \
+     offsetof(struct rt_sigframe, fpstate) + TARGET_FPSTATE_FXSAVE_OFFSET)
+-- 
+2.40.1


### PR DESCRIPTION
This patch for Qemu 8 fixes this issue on Docker Desktop 4.27+: https://github.com/docker/for-mac/issues/7172

A good way to test that the path actually fixes the issue is to run:
`docker run -e POSTGRES_PASSWORD=password -e EXPERIMENTAL_DOCKER_DESKTOP_FORCE_QEMU=1 --rm -it --platform=linux/amd64 postgis/postgis:15-master`