### PR TITLE
test: pin images to manifest digest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,10 +116,10 @@ jobs:
         run: |
           docker run --rm --privileged tonistiigi/binfmt:test --uninstall qemu-*
           docker run --rm --privileged tonistiigi/binfmt:test --install all
-          docker run --rm arm64v8/alpine uname -a
-          docker run --rm arm32v7/alpine uname -a
-          docker run --rm ppc64le/alpine uname -a
-          docker run --rm s390x/alpine uname -a
+          docker run --rm arm64v8/alpine:latest@sha256:ea3c5a9671f7b3f7eb47eab06f73bc6591df978b0d5955689a9e6f943aa368c0 uname -a
+          docker run --rm arm32v7/alpine:latest@sha256:4fdafe217d0922f3c3e2b4f64cf043f8403a4636685cd9c51fea2cbd1f419740 uname -a
+          docker run --rm ppc64le/alpine:latest@sha256:0880443bffa028dfbbc4094a32dd6b7ac25684e4c0a3d50da9e0acae355c5eaf uname -a
+          docker run --rm s390x/alpine:latest@sha256:b815fadf80495594eb6296a6af0bc647ae5f193e0044e07acec7e5b378c9ce2d uname -a
           docker run --rm tonistiigi/debian:riscv uname -a
           docker run --rm yangzewei2023/debian:loongarch64 uname -a
           docker run --rm --platform=linux/s390x s390x/ubuntu apt update

--- a/README.md
+++ b/README.md
@@ -111,10 +111,10 @@ binfmt/9a44d27 qemu/v6.0.0 go/1.15.11
 ## Test current emulation support
 
 ```
-docker run --rm arm64v8/alpine uname -a
-docker run --rm arm32v7/alpine uname -a
-docker run --rm ppc64le/alpine uname -a
-docker run --rm s390x/alpine uname -a
+docker run --rm arm64v8/alpine:latest@sha256:ea3c5a9671f7b3f7eb47eab06f73bc6591df978b0d5955689a9e6f943aa368c0 uname -a
+docker run --rm arm32v7/alpine:latest@sha256:4fdafe217d0922f3c3e2b4f64cf043f8403a4636685cd9c51fea2cbd1f419740 uname -a
+docker run --rm ppc64le/alpine:latest@sha256:0880443bffa028dfbbc4094a32dd6b7ac25684e4c0a3d50da9e0acae355c5eaf uname -a
+docker run --rm s390x/alpine:latest@sha256:b815fadf80495594eb6296a6af0bc647ae5f193e0044e07acec7e5b378c9ce2d uname -a
 docker run --rm tonistiigi/debian:riscv uname -a
 ```
 

--- a/hack/install-and-test
+++ b/hack/install-and-test
@@ -20,11 +20,11 @@ echo $status | jq .supported | grep linux/386
 echo $status | jq .emulators | grep qemu-riscv64
 echo $status | jq .emulators | grep qemu-arm
 
-docker run --rm arm64v8/alpine uname -a
-docker run --rm arm32v7/alpine uname -a
-docker run --rm ppc64le/alpine uname -a
-docker run --rm s390x/alpine uname -a
-docker run --rm i386/alpine uname -a
+docker run --rm arm64v8/alpine:latest@sha256:ea3c5a9671f7b3f7eb47eab06f73bc6591df978b0d5955689a9e6f943aa368c0 uname -a
+docker run --rm arm32v7/alpine:latest@sha256:4fdafe217d0922f3c3e2b4f64cf043f8403a4636685cd9c51fea2cbd1f419740 uname -a
+docker run --rm ppc64le/alpine:latest@sha256:0880443bffa028dfbbc4094a32dd6b7ac25684e4c0a3d50da9e0acae355c5eaf uname -a
+docker run --rm s390x/alpine:latest@sha256:b815fadf80495594eb6296a6af0bc647ae5f193e0044e07acec7e5b378c9ce2d uname -a
+docker run --rm i386/alpine:latest@sha256:dea9f02e103e837849f984d5679305c758aba7fea1b95b7766218597f61a05ab uname -a
 docker run --rm tonistiigi/debian:riscv uname -a
 
 if [ "$(uname -m)" != "x86_64" ]; then exit 0; fi
@@ -41,9 +41,9 @@ echo $status | jq .emulators | grep qemu-ppc64le
 if echo $status | jq .emulators | grep aarch64; then exit 1; fi
 if echo $status | jq .emulators | grep riscv64; then exit 1; fi
 
-if docker run --rm arm64v8/alpine uname -a 2>/dev/null; then exit 1; fi
+if docker run --rm arm64v8/alpine:latest@sha256:ea3c5a9671f7b3f7eb47eab06f73bc6591df978b0d5955689a9e6f943aa368c0 uname -a 2>/dev/null; then exit 1; fi
 
 docker run --rm --privileged tonistiigi/binfmt:${TAG:-test} --install arm64
-docker run --rm arm64v8/alpine uname -a
+docker run --rm arm64v8/alpine:latest@sha256:ea3c5a9671f7b3f7eb47eab06f73bc6591df978b0d5955689a9e6f943aa368c0 uname -a
 
 docker run --rm --privileged tonistiigi/binfmt:${TAG:-test} --install riscv64


### PR DESCRIPTION
tests fail since last month: https://github.com/tonistiigi/binfmt/actions/runs/11813052701/job/32909713187#step:6:76

```
Unable to find image 'arm64v8/alpine:latest' locally
latest: Pulling from arm64v8/alpine
docker: no matching manifest for linux/amd64 in the manifest list entries.
See 'docker run --help'.
```

But was working the week before first failure: https://github.com/tonistiigi/binfmt/actions/runs/11626308529/job/32377744558#step:6:74

```
Unable to find image 'arm64v8/alpine:latest' locally
latest: Pulling from arm64v8/alpine
cf04c63912e1: Pulling fs layer
cf04c63912e1: Verifying Checksum
cf04c63912e1: Download complete
cf04c63912e1: Pull complete
Digest: sha256:9cee2b382fe2412cd77d5d437d15a93da8de373813621f2e4d406e3df0cf0e7c
Status: Downloaded newer image for arm64v8/alpine:latest
WARNING: The requested image's platform (linux/arm64/v8) does not match the detected host platform (linux/amd64/v3) and no specific platform was requested
Linux 2f0d98978cdf 6.5.0-1025-azure #26~22.04.1-Ubuntu SMP Thu Jul 11 22:33:04 UTC 2024 aarch64 Linux
```

After discussion with @thaJeztah, it looks like image format has changes recently. Before it was a single manifest:

```
$ docker buildx imagetools inspect arm64v8/alpine@sha256:9cee2b382fe2412cd77d5d437d15a93da8de373813621f2e4d406e3df0cf0e7c
Name:      docker.io/arm64v8/alpine@sha256:9cee2b382fe2412cd77d5d437d15a93da8de373813621f2e4d406e3df0cf0e7c
MediaType: application/vnd.docker.distribution.manifest.v2+json
Digest:    sha256:9cee2b382fe2412cd77d5d437d15a93da8de373813621f2e4d406e3df0cf0e7c
```

Now it is an OCI index:

```
$ docker buildx imagetools inspect arm64v8/alpine:latest
Name:      docker.io/arm64v8/alpine:latest
MediaType: application/vnd.oci.image.index.v1+json
Digest:    sha256:7d206216871a9feecd6c6689d895889577fdcb28f3f789d8243b3a12f38a2730

Manifests:
  Name:        docker.io/arm64v8/alpine:latest@sha256:ea3c5a9671f7b3f7eb47eab06f73bc6591df978b0d5955689a9e6f943aa368c0
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    linux/arm64/v8
  Annotations:
    org.opencontainers.image.version:         3.20.3
    com.docker.official-images.bashbrew.arch: arm64v8
    org.opencontainers.image.base.name:       scratch
    org.opencontainers.image.created:         2024-11-12T00:54:34Z
    org.opencontainers.image.revision:        7d63673353bd39d92ba42f6effcc199aeebd45ee
    org.opencontainers.image.source:          https://github.com/alpinelinux/docker-alpine.git#7d63673353bd39d92ba42f6effcc199aeebd45ee:aarch64
    org.opencontainers.image.url:             https://hub.docker.com/_/alpine

  Name:        docker.io/arm64v8/alpine:latest@sha256:a8ba68c1a9e6eea8041b4b8f996c235163440808b9654a865976fdcbede0f433
  MediaType:   application/vnd.oci.image.manifest.v1+json
  Platform:    unknown/unknown
  Annotations:
    vnd.docker.reference.type:                attestation-manifest
    com.docker.official-images.bashbrew.arch: arm64v8
    vnd.docker.reference.digest:              sha256:ea3c5a9671f7b3f7eb47eab06f73bc6591df978b0d5955689a9e6f943aa368c0
```

And therefore docker doesn't allow non-matching platform because this is a multi-platform image.