### PR TITLE
test: use ADD for ejabberd test

### DIFF
--- a/test/dockerfiles/ejabberd/Dockerfile
+++ b/test/dockerfiles/ejabberd/Dockerfile
@@ -1,7 +1,4 @@
 FROM alpine:3.15.4 AS build
-ARG REPOSITORY=https://github.com/processone/ejabberd.git
-#ARG VERSION=master
-ARG VERSION=99d9e315a3c0524d84197e63741790d5893c51f4
 
 RUN apk upgrade --update musl \
     && apk add \
@@ -32,9 +29,9 @@ RUN mix local.hex --force \
 
 WORKDIR ejabberd
 
-RUN git clone $REPOSITORY . \
-    && git checkout $VERSION \
-    && mv .github/container/ejabberdctl.template . \
+ADD https://github.com/processone/ejabberd.git#99d9e315a3c0524d84197e63741790d5893c51f4 .
+
+RUN mv .github/container/ejabberdctl.template . \
     && ./autogen.sh \
     && ./configure --with-rebar=mix \
     && make deps \


### PR DESCRIPTION
relates to https://github.com/tonistiigi/binfmt/actions/runs/12197461179/job/34027180497#step:6:163

```
 > [5/5] RUN git clone https://github.com/processone/ejabberd.git .     && git checkout 99d9e315a3c0524d84197e63741790d5893c51f4     && mv .github/container/ejabberdctl.template .     && ./autogen.sh     && ./configure --with-rebar=mix     && make deps     && make rel:
19.34   git switch -c <new-branch-name>
19.34 
19.34 Or undo this operation with:
19.34 
19.34   git switch -
19.34 
19.34 Turn off this advice by setting config variable advice.detachedHead to false
19.34 
19.34 HEAD is now at 99d9e315a Don't set affiliation to 'none' if it's already 'none' in mod_muc_room:process_item_change/3
19.36 Error while loading /ejabberd/./autogen.sh: Exec format error
```