### PR TITLE
Revert disable-pie configure flag

### DIFF
--- a/scripts/configure_qemu.sh
+++ b/scripts/configure_qemu.sh
@@ -62,7 +62,6 @@ set -x
   --disable-mpath \
   --disable-nettle \
   --disable-opengl \
-  --disable-pie \
   --disable-sdl \
   --disable-spice \
   --disable-tools \


### PR DESCRIPTION
We are currently configuring the compilation with `--disable-pie`. This PR removes this flag. In short,  `qemu` maintainers [recommend removing this configuration flag ](https://gitlab.com/qemu-project/qemu/-/issues/1763)since a kernel hardening was introduced, as the two together will cause segmentation faults.  

Further detail: https://github.com/tonistiigi/binfmt/issues/215

