### PR TITLE
test: update ejabberd test to latest release

### DIFF
--- a/test/dockerfiles/ejabberd/Dockerfile
+++ b/test/dockerfiles/ejabberd/Dockerfile
@@ -1,43 +1,45 @@
-FROM alpine:3.15.4 AS build
-ARG REPOSITORY=https://github.com/processone/ejabberd.git
-#ARG VERSION=master
-ARG VERSION=99d9e315a3c0524d84197e63741790d5893c51f4
+# syntax=docker/dockerfile:1
 
-RUN apk upgrade --update musl \
-    && apk add \
-    autoconf \
-    automake \
-    bash \
-    build-base \
-    curl \
-    elixir \
-    erlang-odbc \
-    erlang-reltool \
-    expat-dev \
-    file \
-    gd-dev \
-    git \
-    jpeg-dev \
-    libpng-dev \
-    libwebp-dev \
-    linux-pam-dev \
-    openssl \
-    openssl-dev \
-    sqlite-dev \
-    yaml-dev \
-    zlib-dev
+# https://github.com/processone/ejabberd/blob/master/.github/container/Dockerfile
+
+FROM --platform=$BUILDPLATFORM alpine AS src
+WORKDIR /ejabberd
+ADD --keep-git-dir=true "https://github.com/processone/ejabberd.git#24.12" .
+RUN mv .github/container/ejabberdctl.template .
+
+FROM erlang:27.2-alpine AS build
+RUN apk --update --no-cache add \
+        autoconf \
+        automake \
+        bash \
+        build-base \
+        curl \
+        expat-dev \
+        file \
+        gd-dev \
+        git \
+        jpeg-dev \
+        libpng-dev \
+        libwebp-dev \
+        linux-pam-dev \
+        openssl-dev \
+        sqlite-dev \
+        yaml-dev \
+        zlib-dev
+
+WORKDIR /src/elixir
+RUN wget -q https://github.com/elixir-lang/elixir/archive/v1.18.1.tar.gz -O - | tar xvz --strip 1
 
 ARG QEMU_STRACE
+
+RUN make install clean
 
 RUN mix local.hex --force \
     && mix local.rebar --force
 
-WORKDIR ejabberd
-
-RUN git clone $REPOSITORY . \
-    && git checkout $VERSION \
-    && mv .github/container/ejabberdctl.template . \
-    && ./autogen.sh \
+WORKDIR /src/ejabberd
+COPY --from=src /ejabberd .
+RUN ./autogen.sh \
     && ./configure --with-rebar=mix \
     && make deps \
     && make rel


### PR DESCRIPTION
relates to: https://github.com/tonistiigi/binfmt/actions/runs/13136243038/job/36653417609#step:7:163

```
 > [5/5] RUN git clone https://github.com/processone/ejabberd.git .     && git checkout 99d9e315a3c0524d84197e63741790d5893c51f4     && mv .github/container/ejabberdctl.template .     && ./autogen.sh     && ./configure --with-rebar=mix     && make deps     && make rel:
19.35   git switch -c <new-branch-name>
19.35 
19.35 Or undo this operation with:
19.35 
19.35   git switch -
19.35 
19.35 Turn off this advice by setting config variable advice.detachedHead to false
19.35 
19.35 HEAD is now at 99d9e315a Don't set affiliation to 'none' if it's already 'none' in mod_muc_room:process_item_change/3
19.38 Error while loading /ejabberd/./autogen.sh: Exec format error
```