### PR TITLE
ci: run e2e jobs on ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
           docker buildx build --platform=linux/amd64,linux/arm64,linux/386,linux/arm,linux/ppc64le,linux/s390x --target=run --allow security.insecure --build-arg CONFIG_RT_GROUP_SCHED=false ./test
 
   e2e:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs:
       - prepare
     strategy:


### PR DESCRIPTION
relates to https://github.com/tonistiigi/binfmt/issues/215#issuecomment-2613004741
closes https://github.com/tonistiigi/binfmt/pull/234
