### PR TITLE
ci: move login step right before build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,13 +293,6 @@ jobs:
           name: bake-meta-${{ matrix.target }}
           path: ${{ runner.temp }}
       -
-        name: Login to DockerHub
-        if: startsWith(github.ref, 'refs/heads/')
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERIO_USERNAME }}
-          password: ${{ secrets.DOCKERIO_PASSWORD }}
-      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -307,6 +300,13 @@ jobs:
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+      -
+        name: Login to DockerHub
+        if: startsWith(github.ref, 'refs/heads/')
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_PASSWORD }}
       -
         name: Build
         id: bake


### PR DESCRIPTION
relates to https://github.com/tonistiigi/binfmt/actions/runs/13161078528/job/36737124846#step:6:137

```
  /usr/bin/docker buildx inspect --bootstrap --builder builder-365b40ec-4074-454c-a7d0-ed7f76aa7c5f
  #1 [internal] booting buildkit
  #1 pulling image moby/buildkit:buildx-stable-1 0.1s done
  #1 ERROR: Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
  ------
   > [internal] booting buildkit:
  ------
```

We get rate limited when trying to pull the buildkit image in setup buildx action because user pulling the image is our bot and not one from GitHub Runner that is not rate limited. We should login right before building the image.