### PR TITLE
optimize: update qemu patch 0003 to improve memory efficiency and logic robustness

### DIFF
--- a/patches/buildkit-direct-execve-v10.0/0003-linux-user-path-in-execve-should-be-relative-to-work.patch
+++ b/patches/buildkit-direct-execve-v10.0/0003-linux-user-path-in-execve-should-be-relative-to-work.patch
@@ -1,4 +1,4 @@
-From 0927d01f4f35c8ed3d8639d811fbd2ca49831fa4 Mon Sep 17 00:00:00 2001
+From b05369333c5e7899e88fb1e7863b06c5690990bf Mon Sep 17 00:00:00 2001
 From: CrazyMax <crazy-max@users.noreply.github.com>
 Date: Wed, 3 May 2023 20:54:37 +0200
 Subject: [PATCH 3/7] linux-user: path in execve should be relative to working
@@ -18,14 +18,15 @@ doing an execve syscall, but not if relative filename comes from qemu's argv.
 
 Signed-off-by: Tibor Vass <tibor@docker.com>
 Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>
+Signed-off-by: Zewei Yang <yangzewei@loongson.cn>
 ---
  include/qemu/path.h  |  1 +
  linux-user/syscall.c |  9 +++++++--
- util/path.c          | 32 ++++++++++++++++++++++++++++++++
- 3 files changed, 40 insertions(+), 2 deletions(-)
+ util/path.c          | 33 +++++++++++++++++++++++++++++++++
+ 3 files changed, 41 insertions(+), 2 deletions(-)
 
 diff --git a/include/qemu/path.h b/include/qemu/path.h
-index c6292a9709..a81fb51e1f 100644
+index c6292a9..a81fb51 100644
 --- a/include/qemu/path.h
 +++ b/include/qemu/path.h
 @@ -3,5 +3,6 @@
@@ -36,10 +37,10 @@ index c6292a9709..a81fb51e1f 100644
  
  #endif
 diff --git a/linux-user/syscall.c b/linux-user/syscall.c
-index b9808851e0..c6de1303ae 100644
+index bd8f64e..7a23639 100644
 --- a/linux-user/syscall.c
 +++ b/linux-user/syscall.c
-@@ -8511,12 +8511,17 @@ static int do_execv(CPUArchState *cpu_env, int dirfd,
+@@ -8641,12 +8641,17 @@ static int do_execv(CPUArchState *cpu_env, int dirfd,
       * 		execve(pathname, [argv0, argv1], envp)
       * on the host, becomes:
       * 		execve("/proc/self/exe", [qemu_progname, "-0", argv0, pathname, argv1], envp)
@@ -60,10 +61,10 @@ index b9808851e0..c6de1303ae 100644
      /* copy guest argv1 onwards to host argv4 onwards */
      for (gp = guest_argp + 1*sizeof(abi_ulong), q = argp + 4; gp; gp += sizeof(abi_ulong), q++) {
 diff --git a/util/path.c b/util/path.c
-index 8e174eb436..06fe2663b8 100644
+index 8e174eb..a5afd52 100644
 --- a/util/path.c
 +++ b/util/path.c
-@@ -68,3 +68,35 @@ const char *path(const char *name)
+@@ -68,3 +68,36 @@ const char *path(const char *name)
      qemu_mutex_unlock(&lock);
      return ret;
  }
@@ -90,15 +91,16 @@ index 8e174eb436..06fe2663b8 100644
 +        errno = ERANGE;
 +        return NULL;
 +    }
-+    if (!(p = malloc(k * sizeof(char*)))) return NULL;
++    if (!(p = malloc(k * sizeof(char)))) return NULL;
 +
 +    p[0] = '\0';
 +
-+    if (!strncat(p, buf, i)) return NULL;
-+    if (!strncat(p, "/", 1)) return NULL;
-+    if (!strncat(p, path, j)) return NULL;
++    memcpy(p, buf, i);
++    p[i] = '/';
++    memcpy(p + i + 1, path, j);
++    p[i + 1 + j] = '\0';
 +    return p;
 +}
 -- 
-2.39.3 (Apple Git-146)
+2.47.3
 


### PR DESCRIPTION
Hi ,

I was looking at the QEMU patches included in the patch set and noticed some optimization opportunities in `0003-linux-user-path-in-execve-should-be-relative-to-workdir.patch`.

While the core intent of the patch is correct, the C implementation in util/path.c presents two key areas for optimization to enhance memory efficiency and code robustness:

**Memory Allocation Optimization**: The current implementation uses malloc(k * sizeof(char*)) for memory allocation. On 64-bit systems, char* occupies 8 bytes, resulting in an 8× over-allocation of memory relative to actual requirements. Optimizing this allocation to malloc(k * sizeof(char)) will precisely allocate only the necessary memory, eliminating unnecessary memory overhead and improving memory utilization.

**Logic & Safety Optimization**: The existing code leverages if (!strncat(...)) for error checking. However, strncat returns a pointer to the destination string (never NULL), which renders this check non-functional. Refining the error-checking logic for string concatenation will strengthen the safety and reliability of the code, addressing fragility in the string handling logic.

Thanks！