### PR TITLE
ci: only distribute on pull request events

### DIFF
--- a/.github/workflows/.build.yml
+++ b/.github/workflows/.build.yml
@@ -104,13 +104,14 @@ jobs:
             core.setOutput('git_tag', gitTag);
 
   image:
-    uses: docker/github-builder-experimental/.github/workflows/bake.yml@af87571fd3347a8a760e6053efba57325c00b74b
+    uses: docker/github-builder-experimental/.github/workflows/bake.yml@478a43dbc00a94706d6f106551b49c665c99b64c
     needs:
       - prepare-build
     permissions:
       contents: read # same as global permission
       id-token: write # for signing attestation(s) with GitHub OIDC Token
     with:
+      distribute: ${{ github.event_name == 'pull_request' }}
       setup-qemu: true
       target: ${{ inputs.target }}-all
       output: image
@@ -143,7 +144,7 @@ jobs:
           password: ${{ secrets.DOCKERIO_PASSWORD }}
 
   qemu-archive:
-    uses: docker/github-builder-experimental/.github/workflows/bake.yml@af87571fd3347a8a760e6053efba57325c00b74b
+    uses: docker/github-builder-experimental/.github/workflows/bake.yml@478a43dbc00a94706d6f106551b49c665c99b64c
     if: inputs.target == 'mainline'
     permissions:
       contents: read # same as global permission
@@ -198,7 +199,7 @@ jobs:
           if-no-files-found: error
 
   binfmt-archive:
-    uses: docker/github-builder-experimental/.github/workflows/bake.yml@af87571fd3347a8a760e6053efba57325c00b74b
+    uses: docker/github-builder-experimental/.github/workflows/bake.yml@478a43dbc00a94706d6f106551b49c665c99b64c
     if: inputs.target == 'mainline'
     permissions:
       contents: read # same as global permission


### PR DESCRIPTION
Only distribute build across runners on pull request event. For other events it will build on a single runner to avoid rate limitation.