### PR TITLE
Update aports.config for QEMU 11.0

### DIFF
--- a/patches/aports.config
+++ b/patches/aports.config
@@ -1,3 +1,4 @@
+11.0.0,96d9f625639b8006dc33d4628d2c61ecb81b36c0,linux-user-fix-name_to_handle_at-when-AT_HANDLE_MNT_;fix-strerrorname_np
 10.2.1,7069a045cb08211a5871d7070125225fd6de8c58,linux-user-aarch64-target_fcntl.h-add-missing-TARGET
 10.1.3,4fabd1965b4d7469b4f1b63fd5d3b86838e923d7
 10.0.4,c9b4dbf9a02f4616c7e82fd4b97938da0f058c03


### PR DESCRIPTION
• Implemented the QEMU 11.0 fix in patches/aports.config:1.

  What changed:

  - Added a 11.0.0 Alpine aports mapping pinned to commit 96d9f625639b8006dc33d4628d2c61ecb81b36c0.
  - Skipped two Alpine patches for QEMU 11:
      - linux-user-fix-name_to_handle_at-when-AT_HANDLE_MNT_: already effectively upstream in QEMU 11.
      - fix-strerrorname_np: no longer applies to the QEMU 11 source layout.

Codex created the patch.
Printed version on my arm64 rk3588 nanoPC-T6 and on my x64 dell ntb.

```
REPO_SLUG=myuser/binfmt QEMU_VERSION=v11.0.0 docker buildx bake --load mainline --progress=plain
docker run --rm  myuser/binfmt:test --version
```

binfmt/b4334b8 qemu/v11.0.0 go/1.25.9

`docker run --privileged --rm  myuser/binfmt:test --install all` worked, arm64 emu worked on x64, but it did not seem to fix my numba problem I experienced recently, need some more tests, hopefully on riscv64 too...
