### PR TITLE
Bump qemu to latest patched version

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "QEMU_REPO" {
   default = "https://github.com/qemu/qemu"
 }
 variable "QEMU_VERSION" {
-  default = "v10.2.1"
+  default = "v10.2.3"
 }
 variable "QEMU_PATCHES" {
   default = "cpu-max-arm"


### PR DESCRIPTION
As this fixes bugs, once bumping to 10.2.x we should try to stay in the latest patch