### PR TITLE
ci: skip release when the image build fails

### DIFF
--- a/.github/workflows/.build.yml
+++ b/.github/workflows/.build.yml
@@ -267,7 +267,7 @@ jobs:
 
   release:
     runs-on: ubuntu-24.04
-    if: always()
+    if: ${{ always() && needs.image.result == 'success' && (inputs.target != 'mainline' || (needs.qemu-archive-finalize.result == 'success' && needs.binfmt-archive-finalize.result == 'success')) }}
     needs:
       - prepare-build
       - image


### PR DESCRIPTION
relates to https://github.com/tonistiigi/binfmt/actions/runs/27033730736/job/79798562211#step:4:18

<img width="1597" height="923" alt="image" src="https://github.com/user-attachments/assets/d6434b94-60ca-4eb0-9a23-4507e3869cfc" />

This prevents the reusable release workflow from entering the release preparation path when the image build did not produce metadata.